### PR TITLE
Create team info

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -22,4 +22,23 @@ class StatTracker
     file_open.read
   end
 
+  # ************** Team Statistics **************
+
+  def team_info(team_id)
+    team_info = {}
+
+    #Find the team's row information
+    team = teams.find do |row|
+      team_id == row[0]
+    end
+
+    #Assign hash values
+    team_info["team_id"] = team[0]
+    team_info["franchise_id"] = team[1]
+    team_info["team_name"] = team[2]
+    team_info["abbreviation"] = team[3]
+    team_info["link"] = team[5]
+
+    team_info
+  end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -49,4 +49,17 @@ class StatTrackerTest < Minitest::Test
     assert_equal expected, @stat_tracker.game_teams
   end
 
+  # ************** Team Statistics Tests **************
+
+  def test_it_has_team_info
+    expected = {
+      "team_id" => "4",
+      "franchise_id" => "16",
+      "team_name" => "Chicago Fire",
+      "abbreviation" => "CHI",
+      "link" => "/api/v1/teams/4"
+    }
+    assert_equal expected, @stat_tracker.team_info("4")
+  end
+
 end


### PR DESCRIPTION
This PR:
 - Adds the team_info method that returns a hash of information for a team id.
 - Resolves #10 

I thought that this `team_info` method would be useful for those completing the League Statistics and Season Statistics methods that request a return value for a team name, which is why I'm requesting to merge to main instead of my milestone branch.

You could call `team_info(some_team_id)["team name"]` to get a team's name returned